### PR TITLE
Fixed spelling in function comments (#6248)

### DIFF
--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -506,7 +506,7 @@ class Statistics {
   virtual void recordInHistogram(uint32_t histogramType, uint64_t time) {
     // measureTime() is the old and inaccurate function name.
     // To keep backward compatible. If users implement their own
-    // statistics, which overrides meareTime() but doesn't override
+    // statistics, which overrides measureTime() but doesn't override
     // this function. We forward to measureTime().
     measureTime(histogramType, time);
   }


### PR DESCRIPTION
Summary:
meareTime() -> measureTime()
Pull Request resolved: https://github.com/facebook/rocksdb/pull/6248

Differential Revision: D19231406

Pulled By: riversand963

fbshipit-source-id: 20de4a43a5478b4a3e7853e1fb70b09ccadbf985