### PR TITLE
Re-enable level_compaction_dynamic_level_bytes in crash test (#6251)

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -102,9 +102,7 @@ default_params = {
     "write_dbid_to_manifest" : random.randint(0, 1),
     "max_write_batch_group_size_bytes" : lambda: random.choice(
         [16, 64, 1024 * 1024, 16 * 1024 * 1024]),
-    # Temporarily disabled because of assertion violations in
-    # BlockBasedTable::ApproximateSize
-    # "level_compaction_dynamic_level_bytes" : True,
+    "level_compaction_dynamic_level_bytes" : True,
     "verify_checksum_one_in": 1000000,
     "verify_db_one_in": 100000,
     "continuous_verification_interval" : 0


### PR DESCRIPTION
Summary:
Was probably a false signal suggesting a problem in https://github.com/facebook/rocksdb/issues/6217
Pull Request resolved: https://github.com/facebook/rocksdb/pull/6251

Test Plan: 'make crash_test'

Differential Revision: D19246951

Pulled By: pdillinger

fbshipit-source-id: 3e4fafcd9a7cf5f19ffd207b90279ba615145d6f