### PR TITLE
Fix regression bug in partitioned index reseek caused by #6531 (#6551)

### DIFF
--- a/table/block_based/partitioned_index_iterator.cc
+++ b/table/block_based/partitioned_index_iterator.cc
@@ -14,6 +14,8 @@ void ParititionedIndexIterator::Seek(const Slice& target) { SeekImpl(&target); }
 void ParititionedIndexIterator::SeekToFirst() { SeekImpl(nullptr); }
 
 void ParititionedIndexIterator::SeekImpl(const Slice* target) {
+  SavePrevIndexValue();
+
   if (target) {
     index_iter_->Seek(*target);
   } else {
@@ -25,13 +27,7 @@ void ParititionedIndexIterator::SeekImpl(const Slice* target) {
     return;
   }
 
-  IndexValue v = index_iter_->value();
-  const bool same_block = block_iter_points_to_real_block_ &&
-                          v.handle.offset() == prev_block_offset_;
-
-  if (!same_block) {
-    InitPartitionedIndexBlock();
-  }
+  InitPartitionedIndexBlock();
 
   if (target) {
     block_iter_.Seek(*target);


### PR DESCRIPTION
Summary:
https://github.com/facebook/rocksdb/pull/6531 removed some code in partitioned index seek logic. By mistake the logic of storing previous index offset is removed, while the logic of using it is preserved, so that the code might use wrong value to determine reseeking condition.
This will trigger a bug, if following a Seek() not going to the last block, SeekToLast() is called, and then Seek() is called which should position the cursor to the block before SeekToLast().
Pull Request resolved: https://github.com/facebook/rocksdb/pull/6551

Test Plan: Add a unit test that reproduces the bug. In the same unit test, also some reseek cases are covered to avoid regression.

Reviewed By: pdillinger

Differential Revision: D20493990

fbshipit-source-id: 3919aa4861c0481ec96844e053048da1a934b91d